### PR TITLE
Handle cross-origin errors when parsing styles

### DIFF
--- a/client/django-formset/helpers.ts
+++ b/client/django-formset/helpers.ts
@@ -19,10 +19,18 @@ export namespace StyleHelpers {
 		document.head.appendChild(styleElement);
 		for (let index = 0; index < numStyleSheets; index++) {
 			const sheet = document.styleSheets[index];
-			for (let k = 0; k < sheet.cssRules.length; k++) {
-				const cssRule = sheet.cssRules.item(k);
-				if (cssRule) {
-					traverseStyles(cssRule, styleElement.sheet as CSSStyleSheet);
+			try {
+				for (let k = 0; k < sheet.cssRules.length; k++) {
+					const cssRule = sheet.cssRules.item(k);
+					if (cssRule) {
+						traverseStyles(cssRule, styleElement.sheet as CSSStyleSheet);
+					}
+				}
+			} catch (e) {
+				if (e instanceof DOMException) {
+					console.warn('Could not read stylesheet, try adding crossorigin="anonymous"', sheet, e)
+				} else {
+					throw e;
 				}
 			}
 		}
@@ -31,10 +39,18 @@ export namespace StyleHelpers {
 
 	function traverseStyles(cssRule: CSSRule, extraCSSStyleSheet: CSSStyleSheet) {
 		if (cssRule instanceof CSSImportRule) {
-			if (!cssRule.styleSheet)
-				return;
-			for (let subRule of cssRule.styleSheet.cssRules) {
-				traverseStyles(subRule, extraCSSStyleSheet);
+			try {
+				if (!cssRule.styleSheet)
+					return;
+				for (let subRule of cssRule.styleSheet.cssRules) {
+					traverseStyles(subRule, extraCSSStyleSheet);
+				}
+			} catch (e) {
+				if (e instanceof DOMException) {
+					console.warn('Could not traverse CSS import', cssRule, e)
+				} else {
+					throw e;
+				}
 			}
 		} else if (cssRule instanceof CSSStyleRule) {
 			if (!cssRule.selectorText)


### PR DESCRIPTION
When using external stylesheets, the site can't access their contents due to cross-origin request restriction, which completely breaks the form. 

This PR handles two cases:

1. A top-level stylesheet (`<link rel="stylesheet" href="...">`) is loaded from a different origin (like a CDN):    
in this case, a warning is printed instructing the developer to add `crossorigin="anonymous"` to the `<link>`, which fixes the issue
![console log](https://user-images.githubusercontent.com/3891092/226123822-bb0c9a6c-4f47-4d0e-a3af-7e8e30f79422.png)

2. An accessible (same-origin or `crossorigin="anyonymous"`) stylesheet loads an external stylesheet via `@import`:    
in this case, no workaround exists (that I know of), but a warning is still printed to let the developer know
![console log](https://user-images.githubusercontent.com/3891092/226123632-1c22d013-444b-4e0b-8bfe-9ae0bebdf46b.png)


(Fixes #39)