### PR TITLE
Fix assertUniqueName throwing exception when using MultiWidget

### DIFF
--- a/client/django-formset/DjangoFormset.ts
+++ b/client/django-formset/DjangoFormset.ts
@@ -190,9 +190,9 @@ class FieldGroup {
 		for (const element of this.fieldElements){
 			if (name === '__undefined__') {
 				name = element.name;
-			} 
+			}
 			if (seen.has(element.name)) {
-				throw new Error(`Duplicate name '${name}' on multiple input fields on '${element.name}'`);
+				throw new Error(`Duplicate name '${element.name}' on multiple input fields.`);
 			}
 			seen.add(element.name);
 		}

--- a/client/django-formset/DjangoFormset.ts
+++ b/client/django-formset/DjangoFormset.ts
@@ -186,13 +186,15 @@ class FieldGroup {
 
 	private assertUniqueName() : string {
 		let name = '__undefined__';
-		for (const element of this.fieldElements) {
+		const seen = new Set();
+		for (const element of this.fieldElements){
 			if (name === '__undefined__') {
 				name = element.name;
-			} else {
-				if (name !== element.name)
-					throw new Error(`Duplicate name '${name}' on multiple input fields on '${element.name}'`);
+			} 
+			if (seen.has(element.name)) {
+				throw new Error(`Duplicate name '${name}' on multiple input fields on '${element.name}'`);
 			}
+			seen.add(element.name);
 		}
 		return name;
 	}


### PR DESCRIPTION
assertUniqueName was not checking whether all names in a field group were unique. Instead, it was checking whether all elements in the field group had the same name as the first element of that group.

This led to problems when using field groups with multiple elements, f.ex. when using MultiWidget widgets.

Fixes #61