### PR TITLE
Update reference to django-formset.js

### DIFF
--- a/formset/templates/admin/formset/change_form.html
+++ b/formset/templates/admin/formset/change_form.html
@@ -3,7 +3,8 @@
 
 {% block extrahead %}
 	{{ block.super }}
-	<script type="module" src="{% static 'formset/django-formset.js' %}"></script>
+	<script type="module"
+            src="{% if use_monolithic_build %}{% static 'formset/js/django-formset.monolith.js' %}{% else %}{% static 'formset/js/django-formset.js' %}{% endif %}"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
It appears that this was not updated to reflect the correct location of the JS module.

Or perhaps integrating django-formset with the admin site is no longer supported, in which case this file could be removed?