### PR TITLE
Fix invalid error_messages on Regexfield (testapp customer/phonenumber)

### DIFF
--- a/formset/boundfield.py
+++ b/formset/boundfield.py
@@ -143,13 +143,13 @@ class BoundField(boundfield.BoundField):
             client_messages['type_mismatch'] = client_messages['pattern_mismatch'] = server_messages['invalid']
         elif 'invalid_choice' in server_messages:
             client_messages['type_mismatch'] = server_messages['invalid_choice']
-        if 'bound_ordering' in server_messages:
-            client_messages['custom_error'] = server_messages['bound_ordering']
         else:
             for validator in self.field.validators:
                 validator_code = getattr(validator, 'code', None)
                 if validator_code == 'invalid':
                     client_messages['type_mismatch'] = client_messages['pattern_mismatch'] = validator.message
+        if 'bound_ordering' in server_messages:
+            client_messages['custom_error'] = server_messages['bound_ordering']
         if getattr(self.field, 'max_length', None) is not None:
             data = {'max_length': self.field.max_length}
             max_length_message = _("Ensure this value has at most %(max_length)s characters.")


### PR DESCRIPTION
In PR: https://github.com/jrief/django-formset/pull/94/files

the generation of client error messages broke and no longer reflects the behaviour of django form fields where the Field error_messages dict overrides those set on validators.

In particular the error code "invalid" was impacted, this fix should restore correct behaviour of the client side errors.

The testapp customer form, has a phone number field, this should fix the e2e field test for that field (which I believe is broken right now).