### PR TITLE
Fix common typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ button.
 
 ## Immediate Form Validation
 
-Each field is validated as soon as it looses focus. This gives immediate feedback and signalizes if
+Each field is validated as soon as it loses focus. This gives immediate feedback and signalizes if
 some user input will not be accepted, when submitting the form. The browser side validation
 constraints are excatly the same, as those defined for each Django field in Python.
 


### PR DESCRIPTION
The word "looses" is rather confusing in the English language.

You can "lose" a game. A form field input can "lose" the current focus status.

A knot in a rope can be "loose". An obtuse masseuse, a [Spruce Goose](https://en.wikipedia.org/wiki/Hughes_H-4_Hercules), and an abstruse moose can form a truce and pull a noose "loose" next to a caboose and then vamoose.

And just because English likes to be difficult, the word "loose" can _also_ mean to let go, to intentionally release, usually with great energy or effort. As in: a frisbee can be "loosed" or "set loose", or in a different conjugation: you should "loose" that frisbee down the field but keep track of it the entire way so as to not "lose" it in the bushes. Or: as I am watching them play, he "looses" the frisbee and it sails down the pitch. But people almost never use the word in this way. I've certainly never met anybody who used it this way or read any modern literature that did.

But a form field input never actually controls where the browser is focused, and the browser, being an extension of the user, controls the focused element, and can grant or revoke focus to any element at any time. Therefore, a form field input cannot _loose_ focus, it can only _lose_ focus - the losing of the focus is done _to_ it, rather than it nicely choosing to perform the action itself. In that case, the word "loses" is a better/proper/correct fit for this sentence in your documentation.

This PR fixes that typo.

Also, thanks for your work on this project. It looks pretty neat.