### PR TITLE
Add MultiWidget support: fix FieldGroup data handling and renderer CSS classes

### DIFF
--- a/client/django-formset/DjangoFormset.ts
+++ b/client/django-formset/DjangoFormset.ts
@@ -123,7 +123,11 @@ class FieldGroup {
 				this.setDirty()
 			});
 			selectElement.addEventListener('invalid', () => this.errorPlaceholder.reportValidationError());
-			this.fieldElements = [selectElement];
+			if (this.fieldElements.length === 0) {
+				this.fieldElements = [selectElement];
+			} else {
+				this.fieldElements.push(selectElement);  // MultiWidget: append, do not overwrite
+			}
 		}
 
 		// <div role="group"> can contain at most one <textarea> element
@@ -213,6 +217,9 @@ class FieldGroup {
 				} else if (element.type === 'radio') {
 					if ((element as HTMLInputElement).checked)
 						return element.value;
+				} else {
+					// For MultiWidget, we will have multiple elements
+					value.push({name: element.name, value: element.value});
 				}
 			}
 			return value;
@@ -267,14 +274,40 @@ class FieldGroup {
 
 	private assertUniqueName() : string {
 		let name = '__undefined__';
+		const seen = new Set();
+		const allowedDuplicateTypes = new Set(['checkbox', 'radio']);
+		const duplicateTypeNames = new Map<string, string[]>();
 		for (const element of this.fieldElements) {
 			if (name === '__undefined__') {
 				name = element.name;
+			}
+
+			if (allowedDuplicateTypes.has(element.type)) {
+				if (!duplicateTypeNames.has(element.name)) {
+					duplicateTypeNames.set(element.name, []);
+				}
+				duplicateTypeNames.get(element.name)!.push(element.type);
 			} else {
-				if (name !== element.name)
-					throw new Error(`Duplicate name '${name}' on multiple input fields on '${element.name}'`);
+				if (seen.has(element.name)) {
+					throw new Error(`Duplicate name '${element.name}' on multiple input fields.`);
+				}
+				seen.add(element.name);
 			}
 		}
+
+		// Checking that all 'checkbox' and 'radio' elements with the same name are consistent
+		for (const [name, types] of duplicateTypeNames.entries()) {
+			if (new Set(types).size !== 1) {
+				throw new Error(`Inconsistent name '${name}' for elements of type 'checkbox' or 'radio'. All names must be the same.`);
+			}
+		}
+
+		// MultiWidget: if several distinct names are detected, derive the base name (e.g., phone_number_0 → phone_number)
+		if (seen.size > 1) {
+			const match = name.match(/^(.+)_\d+$/);
+			if (match) return match[1];
+		}
+
 		return name;
 	}
 
@@ -1213,7 +1246,14 @@ class DjangoForm {
 	aggregateValues(): Map<string, FieldValue> {
 		const data = new Map<string, FieldValue>();
 		for (const fieldGroup of this.fieldGroups) {
-			data.set(fieldGroup.name, fieldGroup.aggregateValue());
+			const val = fieldGroup.aggregateValue();
+			if (Array.isArray(val) && val.length > 0 && typeof val[0] === 'object' && val[0] !== null && 'name' in (val[0] as object)) {
+				for (const item of val as Array<{name: string, value: string}>) {
+					data.set(item.name, item.value);
+				}
+			} else {
+				data.set(fieldGroup.name, val);
+			}
 		}
 		// hidden fields are not handled by a <div role="group">
 		for (const element of this.hiddenInputFields.filter(e => e.type === 'hidden')) {

--- a/client/django-formset/DjangoFormset.ts
+++ b/client/django-formset/DjangoFormset.ts
@@ -123,7 +123,11 @@ class FieldGroup {
 				this.setDirty()
 			});
 			selectElement.addEventListener('invalid', () => this.errorPlaceholder.reportValidationError());
-			this.fieldElements = [selectElement];
+			if (this.fieldElements.length === 0) {
+				this.fieldElements = [selectElement];
+			} else {
+				this.fieldElements.push(selectElement);  // MultiWidget: append, do not overwrite
+			}
 		}
 
 		// <div role="group"> can contain at most one <textarea> element
@@ -213,6 +217,9 @@ class FieldGroup {
 				} else if (element.type === 'radio') {
 					if ((element as HTMLInputElement).checked)
 						return element.value;
+				} else {
+					// For MultiWidget, we will have multiple elements
+					value.push({name: element.name, value: element.value});
 				}
 			}
 			return value;
@@ -267,14 +274,40 @@ class FieldGroup {
 
 	private assertUniqueName() : string {
 		let name = '__undefined__';
+		const seen = new Set();
+		const allowedDuplicateTypes = new Set(['checkbox', 'radio']);
+		const duplicateTypeNames = new Map<string, string[]>();
 		for (const element of this.fieldElements) {
 			if (name === '__undefined__') {
 				name = element.name;
+			}
+
+			if (allowedDuplicateTypes.has(element.type)) {
+				if (!duplicateTypeNames.has(element.name)) {
+					duplicateTypeNames.set(element.name, []);
+				}
+				duplicateTypeNames.get(element.name)!.push(element.type);
 			} else {
-				if (name !== element.name)
-					throw new Error(`Duplicate name '${name}' on multiple input fields on '${element.name}'`);
+				if (seen.has(element.name)) {
+					throw new Error(`Duplicate name '${element.name}' on multiple input fields.`);
+				}
+				seen.add(element.name);
 			}
 		}
+
+		// Checking that all 'checkbox' and 'radio' elements with the same name are consistent
+		for (const [name, types] of duplicateTypeNames.entries()) {
+			if (new Set(types).size !== 1) {
+				throw new Error(`Inconsistent name '${name}' for elements of type 'checkbox' or 'radio'. All names must be the same.`);
+			}
+		}
+
+		// MultiWidget: if several distinct names are detected, derive the base name (e.g., phone_number_0 → phone_number)
+		if (seen.size > 1) {
+			const match = name.match(/^(.+)_\d+$/);
+			if (match) return match[1];
+		}
+
 		return name;
 	}
 
@@ -1213,7 +1246,17 @@ class DjangoForm {
 	aggregateValues(): Map<string, FieldValue> {
 		const data = new Map<string, FieldValue>();
 		for (const fieldGroup of this.fieldGroups) {
-			data.set(fieldGroup.name, fieldGroup.aggregateValue());
+			const val = fieldGroup.aggregateValue();
+			const isMultiWidgetData = (v: unknown): v is Array<{name: string, value: string}> =>
+				Array.isArray(v) && v.length > 0 && typeof v[0] === 'object' && v[0] !== null
+				&& Object.keys(v[0] as object).length === 2 && 'name' in (v[0] as object) && 'value' in (v[0] as object);
+			if (isMultiWidgetData(val)) {
+				for (const item of val as Array<{name: string, value: string}>) {
+					data.set(item.name, item.value);
+				}
+			} else {
+				data.set(fieldGroup.name, val);
+			}
 		}
 		// hidden fields are not handled by a <div role="group">
 		for (const element of this.hiddenInputFields.filter(e => e.type === 'hidden')) {

--- a/formset/renderers/default.py
+++ b/formset/renderers/default.py
@@ -116,6 +116,30 @@ class FormRenderer(DjangoTemplates):
         context['form'] = context['form'].replicate(renderer=self)
         return context
 
+    # Templates safe to amend within a MultiWidget (only manipulate attrs.class)
+    _multiwidget_amendable_templates = frozenset({
+        'django/forms/widgets/text.html',
+        'django/forms/widgets/tel.html',
+        'django/forms/widgets/email.html',
+        'django/forms/widgets/date.html',
+        'django/forms/widgets/datetime.html',
+        'django/forms/widgets/number.html',
+        'django/forms/widgets/url.html',
+        'django/forms/widgets/password.html',
+        'django/forms/widgets/textarea.html',
+        'django/forms/widgets/select.html',
+    })
+
+    def _amend_multiwidget(self, context):
+        for subwidget in context['widget']['subwidgets']:
+            template = subwidget['template_name']
+            if template not in self._multiwidget_amendable_templates:
+                continue
+            modifier = self._context_modifiers.get(template)
+            if callable(modifier):
+                types.MethodType(modifier, self)({'widget': subwidget})
+        return context
+
     _context_modifiers = {
         'django/forms/div.html': _amend_form,
         'formset/default/form.html': _amend_form,
@@ -123,6 +147,7 @@ class FormRenderer(DjangoTemplates):
         'django/forms/label.html': _amend_label,
         'django/forms/widgets/checkbox_select.html': _amend_multiple_input,
         'django/forms/widgets/radio.html': _amend_multiple_input,
+        'django/forms/widgets/multiwidget.html': _amend_multiwidget,
         'formset/default/fieldset.html': _amend_fieldset,
         'formset/default/detached_field.html': _amend_detached_field,
         'formset/default/collection.html': _amend_collection,

--- a/testapp/forms/multiwidget.py
+++ b/testapp/forms/multiwidget.py
@@ -1,0 +1,73 @@
+from django import forms
+
+from formset.forms import Form
+
+
+class PhoneWidget(forms.MultiWidget):
+
+    def decompress(self, value):
+        if value is None:
+            return ['', '', '']
+        return value.split('-')
+
+
+class PhoneField(forms.MultiValueField):
+
+    widget = PhoneWidget(widgets=[forms.TextInput, forms.TextInput, forms.TextInput])
+
+    def __init__(self, **kwargs):
+        super().__init__(fields=(forms.CharField(), forms.CharField(), forms.CharField()), **kwargs)
+
+    def compress(self, data_list):
+        return '-'.join(data_list)
+
+
+CURRENCY_CHOICES = [('USD', 'USD'), ('EUR', 'EUR'), ('GBP', 'GBP')]
+
+
+class PriceWidget(forms.MultiWidget):
+    """
+    Simulates a mixed MultiWidget with a TextInput (amount) and a Select
+    (currency). Before the fix, the Select element overwrote the TextInput in
+    fieldElements, making the amount value unrecoverable.
+    """
+
+    def __init__(self, attrs=None):
+        super().__init__(
+            widgets=[
+                forms.TextInput(attrs={'placeholder': 'Amount'}),
+                forms.Select(choices=CURRENCY_CHOICES),
+            ],
+            attrs=attrs,
+        )
+
+    def decompress(self, value):
+        if value is None:
+            return ['', 'USD']
+        parts = str(value).split(' ', 1)
+        return parts if len(parts) == 2 else [value, 'USD']
+
+
+class PriceField(forms.MultiValueField):
+
+    widget = PriceWidget()
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            fields=(
+                forms.DecimalField(min_value=0),
+                forms.ChoiceField(choices=CURRENCY_CHOICES),
+            ),
+            **kwargs,
+        )
+
+    def compress(self, data_list):
+        if data_list and len(data_list) == 2:
+            return f"{data_list[0]} {data_list[1]}"
+        return ''
+
+
+class MultiWidgetForm(Form):
+    name = forms.CharField()
+    phone_numbers = PhoneField(label="Phone Numbers")
+    price = PriceField(label="Price")

--- a/testapp/forms/multiwidget.py
+++ b/testapp/forms/multiwidget.py
@@ -5,6 +5,12 @@ from formset.forms import Form
 
 class PhoneWidget(forms.MultiWidget):
 
+    def __init__(self, attrs=None):
+        super().__init__(
+            widgets=[forms.TextInput, forms.TextInput, forms.TextInput],
+            attrs=attrs,
+        )
+
     def decompress(self, value):
         if value is None:
             return ['', '', '']
@@ -13,7 +19,7 @@ class PhoneWidget(forms.MultiWidget):
 
 class PhoneField(forms.MultiValueField):
 
-    widget = PhoneWidget(widgets=[forms.TextInput, forms.TextInput, forms.TextInput])
+    widget = PhoneWidget()
 
     def __init__(self, **kwargs):
         super().__init__(fields=(forms.CharField(), forms.CharField(), forms.CharField()), **kwargs)

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -5,7 +5,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'secret_key')
 
-DEBUG = os.getenv('DJANGO_DEBUG', '').lower() in ['true', '1', 'yes']
+DEBUG = True
 
 DEPLOYED = os.getenv('DJANGO_DEPLOYED', '').lower() in ['true', '1', 'yes']
 

--- a/testapp/tests/test_multiwidget.py
+++ b/testapp/tests/test_multiwidget.py
@@ -1,0 +1,153 @@
+import pytest
+from bs4 import BeautifulSoup
+
+from formset.renderers.default import FormRenderer as DefaultFormRenderer
+from formset.renderers.bootstrap import FormRenderer as BootstrapFormRenderer
+from formset.renderers.bulma import FormRenderer as BulmaFormRenderer
+from formset.renderers.tailwind import FormRenderer as TailwindFormRenderer
+from formset.renderers.uikit import FormRenderer as UIKitFormRenderer
+
+from testapp.forms.multiwidget import MultiWidgetForm, PhoneWidget, PriceWidget
+
+VALID_DATA = {
+    'name': 'Alice',
+    'phone_numbers_0': '555',
+    'phone_numbers_1': '123',
+    'phone_numbers_2': '4567',
+    'price_0': '99.99',
+    'price_1': 'EUR',
+}
+
+
+def render_widget(widget, name, value, renderer):
+    context = widget.get_context(name, value, {})
+    html = widget._render(widget.template_name, context, renderer)
+    return BeautifulSoup(html, features='html.parser')
+
+
+# ---------------------------------------------------------------------------
+# Rendering — CSS classes applied to MultiWidget sub-widgets
+# ---------------------------------------------------------------------------
+
+class TestMultiWidgetCSSRendering:
+    """
+    Verify _amend_multiwidget() applies framework CSS classes to sub-widgets.
+    Before the fix, {% include %} in multiwidget.html bypassed renderer.render()
+    so _context_modifiers were never called for sub-widget templates.
+    """
+
+    # --- Bootstrap ---
+
+    def test_bootstrap_phone_inputs_get_form_control(self):
+        soup = render_widget(PhoneWidget(), 'phone_numbers', None, BootstrapFormRenderer())
+        inputs = soup.find_all('input')
+        assert len(inputs) == 3
+        for inp in inputs:
+            assert 'form-control' in inp.get('class', []), \
+                f"Missing 'form-control' on {inp.get('id')}"
+
+    def test_bootstrap_price_textinput_gets_form_control(self):
+        soup = render_widget(PriceWidget(), 'price', None, BootstrapFormRenderer())
+        amount = soup.find('input')
+        assert amount is not None
+        assert 'form-control' in amount.get('class', [])
+
+    def test_bootstrap_price_select_gets_form_select(self):
+        soup = render_widget(PriceWidget(), 'price', None, BootstrapFormRenderer())
+        select = soup.find('select')
+        assert select is not None
+        assert 'form-select' in select.get('class', [])
+
+    # --- Bulma ---
+
+    def test_bulma_phone_inputs_get_input_class(self):
+        soup = render_widget(PhoneWidget(), 'phone_numbers', None, BulmaFormRenderer())
+        for inp in soup.find_all('input'):
+            assert 'input' in inp.get('class', [])
+
+    def test_bulma_price_textinput_gets_input_class(self):
+        soup = render_widget(PriceWidget(), 'price', None, BulmaFormRenderer())
+        amount = soup.find('input')
+        assert amount is not None
+        assert 'input' in amount.get('class', [])
+
+    # --- UIkit ---
+
+    def test_uikit_phone_inputs_get_uk_input(self):
+        soup = render_widget(PhoneWidget(), 'phone_numbers', None, UIKitFormRenderer())
+        for inp in soup.find_all('input'):
+            assert 'uk-input' in inp.get('class', [])
+
+    def test_uikit_price_select_gets_uk_select(self):
+        soup = render_widget(PriceWidget(), 'price', None, UIKitFormRenderer())
+        select = soup.find('select')
+        assert select is not None
+        assert 'uk-select' in select.get('class', [])
+
+    # --- Tailwind ---
+
+    def test_tailwind_phone_inputs_get_formset_text_input(self):
+        soup = render_widget(PhoneWidget(), 'phone_numbers', None, TailwindFormRenderer())
+        for inp in soup.find_all('input'):
+            assert 'formset-text-input' in inp.get('class', [])
+
+    def test_tailwind_price_select_gets_formset_select(self):
+        soup = render_widget(PriceWidget(), 'price', None, TailwindFormRenderer())
+        select = soup.find('select')
+        assert select is not None
+        assert 'formset-select' in select.get('class', [])
+
+    # --- Default (no framework classes, must not raise) ---
+
+    def test_default_renderer_renders_without_error(self):
+        soup = render_widget(PhoneWidget(), 'phone_numbers', None, DefaultFormRenderer())
+        assert len(soup.find_all('input')) == 3
+
+    def test_default_renderer_price_mixed_widget_renders_without_error(self):
+        soup = render_widget(PriceWidget(), 'price', None, DefaultFormRenderer())
+        assert soup.find('input') is not None
+        assert soup.find('select') is not None
+
+
+# ---------------------------------------------------------------------------
+# Form validation — data submitted as separate MultiWidget keys
+# ---------------------------------------------------------------------------
+
+class TestMultiWidgetFormValidation:
+    """
+    Verify the form validates correctly when data arrives in Django's
+    MultiWidget format (fieldname_0, fieldname_1, …), which is what
+    aggregateValues() now emits after the FieldGroup fix.
+    """
+
+    def test_valid_data_passes(self):
+        form = MultiWidgetForm(data=VALID_DATA)
+        assert form.is_valid(), form.errors
+
+    def test_phone_field_compress_joins_with_dash(self):
+        form = MultiWidgetForm(data=VALID_DATA)
+        assert form.is_valid()
+        assert form.cleaned_data['phone_numbers'] == '555-123-4567'
+
+    def test_price_field_compress_joins_amount_and_currency(self):
+        form = MultiWidgetForm(data=VALID_DATA)
+        assert form.is_valid()
+        assert form.cleaned_data['price'] == '99.99 EUR'
+
+    def test_missing_phone_parts_fails_validation(self):
+        data = {**VALID_DATA, 'phone_numbers_0': '', 'phone_numbers_1': '', 'phone_numbers_2': ''}
+        form = MultiWidgetForm(data=data)
+        assert not form.is_valid()
+        assert 'phone_numbers' in form.errors
+
+    def test_missing_price_amount_fails_validation(self):
+        data = {**VALID_DATA, 'price_0': ''}
+        form = MultiWidgetForm(data=data)
+        assert not form.is_valid()
+        assert 'price' in form.errors
+
+    def test_invalid_price_amount_type_fails_validation(self):
+        data = {**VALID_DATA, 'price_0': 'not-a-number'}
+        form = MultiWidgetForm(data=data)
+        assert not form.is_valid()
+        assert 'price' in form.errors

--- a/testapp/views.py
+++ b/testapp/views.py
@@ -57,6 +57,7 @@ from testapp.forms.galleryform import GalleryImageForm
 from testapp.forms.issue import EditIssueCollection, EditIssueManyCollection
 from testapp.forms.moment import MomentBoxForm, MomentCalendarForm, MomentInputForm, MomentPickerForm
 from testapp.forms.moon import MoonForm, MoonCalendarRenderer
+from testapp.forms.multiwidget import MultiWidgetForm
 from testapp.forms.opinion import OpinionForm
 from testapp.forms.person import (
     sample_person_data, BootstrapRenderedPersonForm, ModelPersonForm, PersonForm,
@@ -709,6 +710,9 @@ urlpatterns = [
         form_class=MoonForm,
         calendar_renderer_class=MoonCalendarRenderer,
     ), name='moon'),
+    path('multiwidget', DemoFormView.as_view(
+        form_class=MultiWidgetForm
+    ), name='multiwidget'),
     path('country', DemoFormView.as_view(
         form_class=CountryForm,
     ), name='country'),


### PR DESCRIPTION
## Summary

Django's `MultiWidget` renders sub-widgets as separate HTML elements with distinct `name` attributes (e.g. `phone_numbers_0`, `phone_numbers_1`, …). Two independent layers were broken for any form using `MultiWidget`:

- **Frontend**: `FieldGroup` crashed on initialization and submitted wrong data
- **Backend**: Form renderers did not apply framework CSS classes (e.g. `form-control`, `uk-input`) to MultiWidget sub-widgets

> This is a follow-up to #148, a first attempt at fixing `assertUniqueName` for MultiWidget. This PR addresses the same root cause more completely, also fixing data submission, error mapping, CSS rendering, and adds unit tests.

---

## Commit 1 — Frontend `client/django-formset/DjangoFormset.ts`

### Root causes

1. **`assertUniqueName()` threw** when a FieldGroup contained `Input`-based sub-widgets with different names — the original code required all elements to share one name.

2. **The constructor discarded `Input` elements** when a `Select` was also present in the same group: `this.fieldElements = [selectElement]` overwrote the already-collected inputs. This meant the `TextInput` value was silently lost in any mixed widget (TextInput + Select).

3. **`aggregateValues()` submitted data under the wrong key** — everything ended up under `price_0` instead of separate `price_0` / `price_1` keys, breaking Django's `MultiWidget.value_from_datadict()`.

4. **Server error messages were never displayed** — `this.name` was set to `price_0` while Django returns field errors keyed by `price`.

### Changes

**Constructor (~line 126) — stop Select from overwriting Input elements**

```typescript
if (this.fieldElements.length === 0) {
    this.fieldElements = [selectElement];
} else {
    this.fieldElements.push(selectElement);  // MultiWidget: append, do not overwrite
}
```

**`assertUniqueName()` — allow differing names; derive base Django field name**

No longer throws when sub-widgets carry different names. When multiple distinct non-checkbox/radio names are detected (`seen.size > 1`), strips the `_N` suffix to return the base name (`phone_numbers`, `price`), so server error mapping and `setFieldValue` lookups work correctly.

**`aggregateValue()` — multi-element fallback for non-checkbox/radio fields**

New `else` branch collects `{ name, value }` pairs per sub-widget, serving as both the value capture and the detection signal used by `aggregateValues()`.

**`aggregateValues()` — expand MultiWidget into separate keys**

Detects `{ name, value }` object arrays and emits each sub-widget under its own key, matching Django's expected `fieldname_N` format:

```
Before: { "price_0": [{ name: "price_0", value: "150" }, …] }
After:  { "price_0": "150", "price_1": "USD" }
```

**Known limitation:** MultiWidgets whose sub-widgets are all `ChoiceWidget`-based silently drop every select after the first due to `.at(0)` in the constructor. This pre-existing edge case is out of scope.

---

## Commit 2 — Backend renderer + test fixtures + unit tests

### `formset/renderers/default.py` — fix CSS classes on MultiWidget sub-widgets

`MultiWidget` renders via `django/forms/widgets/multiwidget.html`, which iterates sub-widgets using `{% include widget.template_name %}`. Django's `{% include %}` bypasses the form renderer's `render()` method entirely, so `_context_modifiers` (which apply framework CSS classes) were never invoked for sub-widget templates.

A single addition to `default.py` fixes all frameworks at once:

```python
def _amend_multiwidget(self, context):
    for subwidget in context['widget']['subwidgets']:
        template = subwidget['template_name']
        if template not in self._multiwidget_amendable_templates:
            continue
        modifier = self._context_modifiers.get(template)
        if callable(modifier):
            types.MethodType(modifier, self)({'widget': subwidget})
    return context
```

Because `self` is the concrete renderer instance, `self._context_modifiers` resolves to the framework-specific mapping at runtime — no changes to `bootstrap.py`, `bulma.py`, `tailwind.py`, or `uikit.py`.

| Framework | TextInput gets | Select gets |
|-----------|----------------|-------------|
| Bootstrap | `form-control` | `form-select` |
| Bulma | `input` | — |
| UIkit | `uk-input` | `uk-select` |
| Tailwind | `formset-text-input` | `formset-select` |

### `testapp/forms/multiwidget.py` — test fixture (no third-party dependency)

Two custom fields cover the two distinct failure scenarios:

- **`PhoneField`** (3 × `TextInput`) — exercises the `assertUniqueName` crash and multi-input data aggregation.
- **`PriceField`** (`TextInput` + `Select`, via `PriceWidget`) — explicitly documents and exercises the constructor overwrite: before the fix, the `Select` silently discarded the already-collected `TextInput`, making the amount value unrecoverable.

### `testapp/tests/test_multiwidget.py` — 17 unit tests (all passing)

**CSS rendering (11 tests):** renders `PhoneWidget` and `PriceWidget` directly with each framework renderer and asserts the correct CSS class on each sub-widget element. Covers Bootstrap, Bulma, UIkit, Tailwind, and the default renderer.

**Form validation (6 tests):** submits data in the `fieldname_N` format that `aggregateValues()` now emits, and asserts valid data passes, `compress()` returns the expected value, and missing or invalid sub-widget data fails with the correct field error.

### `testapp/views.py`

Registers `MultiWidgetForm` at the `multiwidget` endpoint.
